### PR TITLE
changed 2nd h1p to h2p

### DIFF
--- a/Colour.js
+++ b/Colour.js
@@ -286,7 +286,7 @@ class Colour {
 			h2p = h2p + 360;
 		}
 
-		const avghp = Math.abs(h1p - h2p) > 180 ? (h1p + h2p + 360) / 2 : (h1p + h1p) / 2;
+		const avghp = Math.abs(h1p - h2p) > 180 ? (h1p + h2p + 360) / 2 : (h1p + h2p) / 2;
 
 		const T = 1 - 0.17 * Math.cos(Math.deg2rad(avghp - 30)) + 0.24 * Math.cos(Math.deg2rad(2 * avghp)) + 0.32 * Math.cos(Math.deg2rad(3 * avghp + 6)) - 0.2 * Math.cos(Math.deg2rad(4 * avghp - 63));
 


### PR DESCRIPTION
Hello! In testing my own implementation of the Delta-E 2000 formula (http://www.brucelindbloom.com/index.html?Eqn_DeltaE_CIE2000.html) I noticed that this implementation calculated ```(h1p + h1p)/2``` rather than ```(h1p + h2p)/2``` in the ternary expression for the ```avghp``` computation.